### PR TITLE
Integrar cámara para agregar foto a comentario (opcionalmente)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,8 @@
 
 .idea
 
+# Ignore environment variables.
 .env
+
+# Ignore images saved in Disk.
+/storage

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -181,3 +181,11 @@ html {
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+
+.comment-image {
+  width: 700px;
+  height: 700px;
+  object-fit: cover;
+  transform: rotate(90deg);
+}

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -76,6 +76,6 @@ class CommentsController < ApplicationController
   end
 
   def comment_params
-    params.require(:comment).permit(:content, :user_id, :name, :email, :rating, :category)
+    params.require(:comment).permit(:content, :user_id, :name, :email, :rating, :category, :image)
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,6 +1,11 @@
 class Comment < ApplicationRecord
   belongs_to :user
+  has_one_attached :image
   validates :content, presence: true
   validates :rating, presence: true
   validates :category, presence: true
+
+  def comment_image
+    image.variant(resize: '400x300', rotate: '90', auto_orient: true)
+  end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -4,8 +4,4 @@ class Comment < ApplicationRecord
   validates :content, presence: true
   validates :rating, presence: true
   validates :category, presence: true
-
-  def comment_image
-    image.variant(resize: '400x300', rotate: '90', auto_orient: true)
-  end
 end

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -15,6 +15,9 @@
             </p>
             <p>Calificación: <%= comment.rating %></p>
             <p>Categoría: <%= comment.category %></p>
+            <% if comment.image.attached? %>
+              <b>Se incluyó una imagen en el comentario</b>
+            <% end %>
           </div>
           <div class="panel-footer">
             <div class="row">

--- a/app/views/comments/new.html.erb
+++ b/app/views/comments/new.html.erb
@@ -2,7 +2,7 @@
   <div class="row">
     <h1 class="center form-header">Enviar queja o sugerencia a <b><%= @user.name %></b></h1>
     <div>
-      <form class="form-horizontal" action="/comments" method="post">
+      <form class="form-horizontal" action="/comments" method="post" enctype="multipart/form-data">
         <input type="hidden" name="authenticity_token" value="<%= form_authenticity_token %>">
 
         <div class="form-group">
@@ -49,6 +49,14 @@
           <label for="comment_content" class="col-sm-3 control-label">Comentario</label>
           <div class="col-sm-9 col-lg-6">
             <textarea name="comment[content]" id="comment_content" class="form-control" rows="8"></textarea>
+          </div>
+        </div>
+
+        <div class="form-group">
+          <label for="comment_image" class="col-sm-3 control-label">Imagen (Opcional) </label>
+          <div class="col-sm-9 col-lg-6">
+            <input type="file" name="comment[image]" id="comment_image" class="form-control" accept="image/*"
+                   capture="camera"/>
           </div>
         </div>
 

--- a/app/views/comments/show.html.erb
+++ b/app/views/comments/show.html.erb
@@ -16,6 +16,9 @@
         </p>
         <p>Calificación: <%= @comment.rating %></p>
         <p>Categoría: <%= @comment.category %></p>
+        <% if @comment.image.attached? %>
+          <img id="image" class="comment-image" align="middle" src="<%= url_for(@comment.image)%>" alt="" />
+        <% end %>
       </div>
       <div class="panel-footer">
         <div class="row">

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,9 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  #config.web_console.whitelisted_ips = %w( 127.0.0.1 0.0.0.0 192.168.0.7)
+  config.web_console.whiny_requests = false
+
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
@@ -53,4 +56,6 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.active_storage.service = :local
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,4 +39,6 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  config.active_storage.service = :local
 end

--- a/config/spring.rb
+++ b/config/spring.rb
@@ -4,3 +4,11 @@
   tmp/restart.txt
   tmp/caching-dev.txt
 ).each { |path| Spring.watch(path) }
+Spring.after_fork do
+  if ENV['DEBUGGER_STORED_RUBYLIB']
+    ENV['DEBUGGER_STORED_RUBYLIB'].split(File::PATH_SEPARATOR).each do |path|
+      next unless path =~ /ruby-debug-ide/
+      load path + '/ruby-debug-ide/multiprocess/starter.rb'
+    end
+  end
+end

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,0 +1,7 @@
+local:
+  service: Disk
+  root: <%= Rails.root.join("storage") %>
+
+test:
+  service: Disk
+  root: <%= Rails.root.join("tmp/storage") %>

--- a/db/migrate/20190630160402_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20190630160402_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,27 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,        null: false
+      t.string   :filename,   null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.bigint   :byte_size,  null: false
+      t.string   :checksum,   null: false
+      t.datetime :created_at, null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,31 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_12_033023) do
+ActiveRecord::Schema.define(version: 2019_06_30_160402) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
 
   create_table "comments", force: :cascade do |t|
     t.text "content"
@@ -46,4 +67,5 @@ ActiveRecord::Schema.define(version: 2019_06_12_033023) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
 end


### PR DESCRIPTION
- Configuración de Rails Active Storage para administrar imagenes
- Se puede, opcionalmente, tomar una foto con la cámara y adjuntarla en el comentario. El administrador ve esta foto en el detalle del comentario