### PR TITLE
Dar de alta productos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@
 
 # Ignore images saved in Disk.
 /storage
+
+.etc
+
+vendor/

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
+ruby '2.5.1'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails'

--- a/app/controllers/enable_reports_controller.rb
+++ b/app/controllers/enable_reports_controller.rb
@@ -1,0 +1,18 @@
+class EnableReportsController < ApplicationController
+
+  protect_from_forgery with: :null_session
+
+  # GET /print
+  def updateReports
+    user = User.find(params[:id])
+    user.has_reports = true
+    user.save
+  end
+
+  def updateBenchmark
+    user = User.find(params[:id])
+    user.has_benchmark = true
+    user.save
+  end
+
+end

--- a/app/views/main/index.html.erb
+++ b/app/views/main/index.html.erb
@@ -1,6 +1,9 @@
 <h2>Menú principal</h2>
+
+<% if @current_user.has_reports %>
+  <div><%= link_to 'Ver reportes', {controller: 'reports', action: 'index'}, :class => 'show-reports' %></div>
+<% end %>
 <div><%= link_to 'Ver comentarios', {controller: 'comments', action: 'index'}, :class => 'show-comments' %></div>
-<div><%= link_to 'Ver reportes', {controller: 'reports', action: 'index'}, :class => 'show-reports' %></div>
 <div class="row">
   <div class="col-sm-4"></div>
   <div class="col-sm-3 center">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,4 +15,7 @@ Rails.application.routes.draw do
   get 'print', to: 'print#index'
   #get ':shop_name' , to: 'comments#new_whit_shop_name'
   get 'reports', to: 'reports#index'
+
+  put 'enable_reports', to: 'enable_reports#updateReports'
+  put 'enable_benchmark', to: 'enable_reports#updateBenchmark'
 end

--- a/db/migrate/20190703235159_add_products_to_users.rb
+++ b/db/migrate/20190703235159_add_products_to_users.rb
@@ -1,0 +1,6 @@
+class AddProductsToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :has_reports, :boolean, default: false
+    add_column :users, :has_benchmark, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_30_160402) do
+ActiveRecord::Schema.define(version: 2019_07_03_235159) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -62,6 +62,8 @@ ActiveRecord::Schema.define(version: 2019_06_30_160402) do
     t.datetime "updated_at", null: false
     t.string "name", default: "", null: false
     t.string "hash_for_url", default: "", null: false
+    t.boolean "has_reports", default: false
+    t.boolean "has_benchmark", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["hash_for_url"], name: "index_users_on_hash_for_url", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
La idea es que cuando se registra un usuario, no tenga benchmark ni reportes.
Si desea contratar alguno de los productos, lo damos de alta.
En otro PR implemento la baja de un producto.